### PR TITLE
add .d.ts file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+declare const plugin: { handler: () => void };
+
+export = plugin;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,3 @@
-declare const plugin: { handler: () => void };
+declare const plugin: { handler: () => void }
 
-export = plugin;
+export = plugin


### PR DESCRIPTION
this adds a `.d.ts` file to make typescript happy when importing the plugin in `tailwind.config.ts` or with `allowJs`/`@ts-check`.

matches what other plugins do ([example](https://github.com/tailwindlabs/tailwindcss-line-clamp/blob/master/src/index.d.ts)).