### PR TITLE
fix:moved animation name and duration to theme extension for the sake of css modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,11 +9,7 @@ function filterDefault(values) {
 module.exports = plugin(
 	({ addUtilities, matchUtilities, theme }) => {
 		addUtilities({
-			"@keyframes enter": theme("keyframes.enter"),
-			"@keyframes exit": theme("keyframes.exit"),
 			".animate-in": {
-				animationName: "enter",
-				animationDuration: theme("animationDuration.DEFAULT"),
 				"--tw-enter-opacity": "initial",
 				"--tw-enter-scale": "initial",
 				"--tw-enter-rotate": "initial",
@@ -21,8 +17,6 @@ module.exports = plugin(
 				"--tw-enter-translate-y": "initial",
 			},
 			".animate-out": {
-				animationName: "exit",
-				animationDuration: theme("animationDuration.DEFAULT"),
 				"--tw-exit-opacity": "initial",
 				"--tw-exit-scale": "initial",
 				"--tw-exit-rotate": "initial",
@@ -166,6 +160,10 @@ module.exports = plugin(
 					1: "1",
 					infinite: "infinite",
 				},
+				animation: ({ theme }) => ({
+					out: `leave ${theme("animationDuration.DEFAULT")}`,
+					in: `enter ${theme("animationDuration.DEFAULT")}`,
+				}),
 				keyframes: {
 					enter: {
 						from: {

--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ module.exports = plugin(
 					infinite: "infinite",
 				},
 				animation: ({ theme }) => ({
-					out: `leave ${theme("animationDuration.DEFAULT")}`,
+					out: `exit ${theme("animationDuration.DEFAULT")}`,
 					in: `enter ${theme("animationDuration.DEFAULT")}`,
 				}),
 				keyframes: {


### PR DESCRIPTION
#### **moved animation name and duration to theme extension for the sake of css modules otherwise tailwind won't know that the `@keyframes` are associated with any ainmation e.g `.animation-in` , `.animation-out`** and therefore won't inject the keyframes in the document head

### steps to reproduce
>try to use any of the library animations in a `.module.css` file with tailwind's `@apply` directive

##### [CREDITS](https://github.com/tailwindlabs/tailwindcss/discussions/11164#discussioncomment-5819097)