### PR TITLE
Fix: Support css variables in translation calculations

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,25 +58,25 @@ module.exports = plugin(
 		matchUtilities(
 			{
 				"slide-in-from-top": (value) => ({
-					"--tw-enter-translate-y": `-${value}`,
+					"--tw-enter-translate-y": `calc(-1 * ${value})`,
 				}),
 				"slide-in-from-bottom": (value) => ({
 					"--tw-enter-translate-y": value,
 				}),
 				"slide-in-from-left": (value) => ({
-					"--tw-enter-translate-x": `-${value}`,
+					"--tw-enter-translate-x": `calc(-1 * ${value})`,
 				}),
 				"slide-in-from-right": (value) => ({
 					"--tw-enter-translate-x": value,
 				}),
 				"slide-out-to-top": (value) => ({
-					"--tw-exit-translate-y": `-${value}`,
+					"--tw-exit-translate-y": `calc(-1 * ${value})`,
 				}),
 				"slide-out-to-bottom": (value) => ({
 					"--tw-exit-translate-y": value,
 				}),
 				"slide-out-to-left": (value) => ({
-					"--tw-exit-translate-x": `-${value}`,
+					"--tw-exit-translate-x": `calc(-1 * ${value})`,
 				}),
 				"slide-out-to-right": (value) => ({
 					"--tw-exit-translate-x": value,


### PR DESCRIPTION
### Summary

We use css variable references in our custom tailwind theme instead of standard hardcoded values. Currently, this results in mangled values when using this library:

```css
.data-\[side\=bottom\]\:slide-in-from-top-2[data-side="bottom"] {
    --tw-enter-translate-y: -var(--spacing-2);
}
```

This PR addresses the issue my moving to `calc(...)` where relevant to allow usage of css variables. Given there are no recommendations from tailwind I'm aware of warning users *not* to use css tokens for spacing theme values, I've just adjusted tailwindcss-animate slightly to resolve.

Happy to discuss questions/concerns or close if this feels too niche a usecse.